### PR TITLE
Remove unnecessary GConf from dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 # install elementary-sdk, meson and libwingpanel
 sudo apt install elementary-sdk meson libwingpanel-2.0-dev
 #install dependencies
-sudo apt install libgconf2-dev libglib2.0-dev libgranite-dev libxml2-dev
+sudo apt install libglib2.0-dev libgranite-dev libxml2-dev
 # clone repository
 git clone https://github.com/maze-n/wingpanel-indicator-daynight.git wingpanel-indicator-daynight
 # cd to dir

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,6 @@ add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(gettext_name), language:'c
 wingpanel_dep = dependency('wingpanel-2.0')
 
 dependencies = [
-    dependency('gconf-2.0'),
     dependency('glib-2.0'),
     dependency('gobject-2.0'),
     dependency('granite'),


### PR DESCRIPTION
It seems like GConf is included as a dependency but not used.
