### PR TITLE
Make everything translatable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('com.github.maze-n.indicator-daynight', 'vala', 'c')
 
+i18n = import('i18n')
 gettext_name = meson.project_name()
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format(gettext_name), language:'c')
@@ -29,6 +30,7 @@ shared_module(
     install_dir : wingpanel_dep.get_pkgconfig_variable('indicatorsdir')
 )
 
-subdir('data/')
+subdir('data')
+subdir('po')
 
 meson.add_install_script('meson/post_install.py')

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,0 +1,1 @@
+src/Indicator.vala

--- a/po/com.github.maze-n.indicator-daynight.pot
+++ b/po/com.github.maze-n.indicator-daynight.pot
@@ -1,0 +1,48 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the com.github.maze-n.indicator-daynight package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: com.github.maze-n.indicator-daynight\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-02-11 07:45+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/Indicator.vala:33
+msgid "Daynight"
+msgstr ""
+
+#: src/Indicator.vala:34
+msgid ""
+"A wingpanel indicator to toggle 'prefer dark variant' option in elementary "
+"OS."
+msgstr ""
+
+#: src/Indicator.vala:67
+msgid "Restart Dock"
+msgstr ""
+
+#: src/Indicator.vala:70
+msgid "Indicator Settings…"
+msgstr ""
+
+#: src/Indicator.vala:113
+msgid "Restart dock on toggling"
+msgstr ""
+
+#: src/Indicator.vala:122
+msgid "Show restart button on indicator"
+msgstr ""
+
+#: src/Indicator.vala:131
+msgid "Apply"
+msgstr ""

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,0 +1,6 @@
+i18n.gettext(gettext_name,
+    args: [
+        '--directory=' + meson.source_root()
+    ],
+    preset: 'glib'
+)

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -29,9 +29,9 @@ public class Daynight.Indicator : Wingpanel.Indicator {
 
     public Indicator () {
         Object (
-            code_name: "Daynight",
-            display_name: _("indicator-daynight"),
-            description:_("A wingpanel indicator to toggle 'prefer dark variant' option in Elementary OS.")
+            code_name: "indicator-daynight",
+            display_name: _("Daynight"),
+            description: _("A wingpanel indicator to toggle 'prefer dark variant' option in elementary OS.")
         );
     }
 
@@ -64,10 +64,10 @@ public class Daynight.Indicator : Wingpanel.Indicator {
         display_icon = new Gtk.Image.from_icon_name (indicator_logo, Gtk.IconSize.LARGE_TOOLBAR);
 
         restart_button = new Gtk.ModelButton();
-        restart_button.text = "Restart Dock...";
+        restart_button.text = _("Restart Dock");
 
         settings_button = new Gtk.ModelButton();
-        settings_button.text = "Indicator Settings...";
+        settings_button.text = _("Indicator Settings…");
 
         main_grid = new Gtk.Grid();
         main_grid.attach(toggle_switch, 0, 0);
@@ -110,7 +110,7 @@ public class Daynight.Indicator : Wingpanel.Indicator {
 
         var content_area = settings_dialog.get_content_area();
 
-        var restart_on_toggle_switch = new Wingpanel.Widgets.Switch("Restart dock on toggling", settings.get_boolean("restart-on-toggle"));
+        var restart_on_toggle_switch = new Wingpanel.Widgets.Switch(_("Restart dock on toggling"), settings.get_boolean("restart-on-toggle"));
         restart_on_toggle_switch.notify["active"].connect (() => {
             if(restart_on_toggle_switch.active) {
                 settings.set_boolean("restart-on-toggle", true);
@@ -119,7 +119,7 @@ public class Daynight.Indicator : Wingpanel.Indicator {
             }
         });
 
-        var show_restartbutton_switch = new Wingpanel.Widgets.Switch("Show restart button on indicator", settings.get_boolean("button-show"));
+        var show_restartbutton_switch = new Wingpanel.Widgets.Switch(_("Show restart button on indicator"), settings.get_boolean("button-show"));
         show_restartbutton_switch.notify["active"].connect (() => {
             if(show_restartbutton_switch.active) {
                 settings.set_boolean("button-show", true);
@@ -128,7 +128,7 @@ public class Daynight.Indicator : Wingpanel.Indicator {
             }
         });
 
-        var apply_button = new Gtk.Button.with_label("Apply");
+        var apply_button = new Gtk.Button.with_label(_("Apply"));
         apply_button.halign = Gtk.Align.CENTER;
         apply_button.get_style_context().add_class("suggested-action");
         apply_button.clicked.connect(() => {


### PR DESCRIPTION
## Changes Summary
- Make it possible to translate all strings shown in the UI
- Fix `code_name` and `display_name` is reversed
- "elementary OS" should be always lower-case (see also: https://elementary.io/en/brand)
- Proper use of `…` (Clicking the label "Restart Dock" immediately restarts Dock and there are no confirmation or inputs from the user, so we may not want to use it here. See also [elementary HIG](https://elementary.io/ja/docs/human-interface-guidelines#using-ellipses))
- Use `…` instead of three periods (which is recommended in [elementary HIG](https://elementary.io/ja/docs/human-interface-guidelines#using-ellipses))
