### PR TITLE
Indicator: Remove deprecated display_name and description

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -29,9 +29,7 @@ public class Daynight.Indicator : Wingpanel.Indicator {
 
     public Indicator () {
         Object (
-            code_name: "indicator-daynight",
-            display_name: _("Daynight"),
-            description: _("A wingpanel indicator to toggle 'prefer dark variant' option in elementary OS.")
+            code_name: "indicator-daynight"
         );
     }
 


### PR DESCRIPTION
These properties are already deprecated as of the latest release of Wingpanel and will be completely removed in Wingpanel 3.0.0.
